### PR TITLE
Add store composition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - "lts/boron"

--- a/src/store.js
+++ b/src/store.js
@@ -13,6 +13,12 @@ export default class Store {
     this.state = Object.assign({}, this.state, newState)
     this.subscriptions.forEach(sub => sub(this.state))
   }
-}
 
+  mount(path, subStore) {
+    subStore.setState(this.state[path])
+    this.state[path] = subStore.state
+    this[path] = subStore
+    subStore.subscribe((newState) => this.setState({ [path]: newState }))
+  }
+}
 

--- a/test/composition.js
+++ b/test/composition.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai'
+
+import { Store } from '../src'
+
+class MainStore extends Store {
+
+}
+
+class SubStore extends Store {
+  state = { name: '' }
+
+  setName(name) {
+    this.setState({ name })
+  }
+}
+
+const createStore = (initialState, otherStoreInitialState) => {
+  const store = new MainStore(initialState)
+  store.mount('subStore', new SubStore())
+  store.mount('otherStore', new SubStore(otherStoreInitialState))
+  return store
+}
+
+describe('composition', () => {
+  describe('with no initial state', () => {
+    it('mounts both substores and exposes them', () => {
+      const store = createStore()
+      expect(store.state).to.eql({
+        subStore: { name: '' },
+        otherStore: { name: '' }
+      })
+    })
+  })
+
+  it('passes changes from subStore to main', (done) => {
+    const store = createStore()
+    store.subscribe(state => {
+      expect(state).to.eql({
+        subStore: { name: 'foo' },
+        otherStore: { name: '' }
+      })
+      done()
+    })
+    store.subStore.setName('foo')
+  })
+
+  describe('intial state', () => {
+    it('is passed to subStore based on namespace', () => {
+      const store = createStore({ subStore: { name: 'bar' } })
+      expect(store.state).to.eql({
+        subStore: { name: 'bar' },
+        otherStore: { name: '' }
+      })
+    })
+  })
+})

--- a/test/connect.js
+++ b/test/connect.js
@@ -38,6 +38,15 @@ describe('connect', () => {
     expect(el.text()).to.equal('foo')
   })
 
+  it('does not pass store prototype methods to connected component', () => {
+    const store = new Store({ name: 'foo' })
+    const el = mount(<ConnectedThing store={store} />)
+    const child = el.find(Thing)
+    expect(child.props().name).to.equal('foo')
+    expect(child.props().mount).to.equal(undefined)
+    expect(child.props().setState).to.equal(undefined)
+  })
+
   it('re-renders component when store changes', () => {
     const store = new Store({ name: 'foo' })
     const el = mount(<ConnectedThing store={store} />)

--- a/test/connect.js
+++ b/test/connect.js
@@ -22,6 +22,8 @@ class Thing extends Component {
 
 const ConnectedThing = connect()(Thing)
 
+class SubStore extends Store { }
+
 describe('connect', () => {
   it('hoists statics', () => {
     expect(Thing.myStatic()).to.equal(true)
@@ -39,7 +41,7 @@ describe('connect', () => {
   })
 
   it('does not pass store prototype methods to connected component', () => {
-    const store = new Store({ name: 'foo' })
+    const store = new SubStore({ name: 'foo' })
     const el = mount(<ConnectedThing store={store} />)
     const child = el.find(Thing)
     expect(child.props().name).to.equal('foo')

--- a/test/store.js
+++ b/test/store.js
@@ -32,6 +32,11 @@ describe('store', () => {
     store.setState({ test: true })
   })
 
+  it('supports initial state', () => {
+    const store = new Store({ foo: 'bar' })
+    expect(store.state).to.eql({ foo: 'bar' })
+  })
+
   describe('Subclassed', () => {
     class MyStore extends Store {
       state = { name: 'test' }


### PR DESCRIPTION
This allows 'nested' stores so you can namespace larger state trees rather than having one single (ever growing) store for your app as your app takes on more features.